### PR TITLE
mark all previously checks as cancelled

### DIFF
--- a/index.js
+++ b/index.js
@@ -80,6 +80,18 @@ Toolkit.run(
 
     const statuses = [title_passed, branch_passed, commits_passed]
 
+    await tools.github.checks.listForRef(Object.assign({'status': 'completed'}, repoInfo))
+      .check_runs
+      .filter(check_run => {check_run.name === "pr_lint"})
+      .forEach(check_run => {
+        tools.github.checks.update({
+          owner: repository.owner.login,
+          repo: repository.name,
+          check_run_id: check_run.id,
+          conclusion: 'cancelled',
+        })
+      })
+
     if (statuses.some(status => status === false )){
       tools.exit.failure("PR Linting Failed")
     } else {


### PR DESCRIPTION
This should fix the issue when previously failed PR checks (such as incorrect PR title) prevent merge action.